### PR TITLE
Add material-ui to the list of npm keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "keywords": [
     "react",
     "material",
+    "material-ui",
     "rating",
     "react-component"
   ],


### PR DESCRIPTION
I would like to enable a third-party component search for Material-UI components like Gatsby is doing it with its plugins page: https://www.gatsbyjs.org/plugins/.