### PR TITLE
update Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install material-ui-rating
 
 ## Usage
 ```js
-import { Rating } from 'material-ui-rating'
+import Rating from 'material-ui-rating'
 
 <Rating
   value={3}


### PR DESCRIPTION
used default import instead of named import in the example because it was giving an error.